### PR TITLE
Updated the gitignore because of the prescription model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+#Prescription models
+roman_preflight.py
+roman_preflight_compact.py


### PR DESCRIPTION
To run corgisim, we need copy the prescription model to the local directory. Now added prescription model to .gitignore so we will not keep track of these files. 