### PR TITLE
Only run checks when a PR is ready for review

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [ready_for_review]
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Otherwise it's annoying and using up resources unnecessarily.