### PR TITLE
Add notebook to create single-actuator probes

### DIFF
--- a/sandbox/ilag/single_actuator_probes.ipynb
+++ b/sandbox/ilag/single_actuator_probes.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fc3a50c-d1a2-4d53-9487-321e8d73b82b",
+   "metadata": {},
+   "source": [
+    "# Single-actuator probe files\n",
+    "\n",
+    "Create single-actuator probes to stick into the GITL nulling test in `cgi-howfsc`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69776caa-3903-42cf-8826-15d826084b33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from matplotlib.colors import TwoSlopeNorm\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from astropy.io import fits\n",
+    "\n",
+    "import howfsc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cc8b968-3c44-4cf4-baa2-1cbca69b294a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For mode = 'narrowfov'\n",
+    "howfscpath = os.path.dirname(os.path.abspath(howfsc.__file__))\n",
+    "modelpath = os.path.join(howfscpath, 'model', 'testdata', 'narrowfov')\n",
+    "\n",
+    "probe0file = os.path.join(modelpath, 'narrowfov_dmrel_1.0e-05_cos.fits')\n",
+    "probe1file = os.path.join(modelpath, 'narrowfov_dmrel_1.0e-05_sinlr.fits')\n",
+    "probe2file = os.path.join(modelpath, 'narrowfov_dmrel_1.0e-05_sinud.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2eb39334-862e-4ed1-9bef-d08f9e34555f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sin0probe = fits.getdata(probe0file)\n",
+    "sin1probe = fits.getdata(probe1file)\n",
+    "sin2probe = fits.getdata(probe2file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a3e8caf-0882-462a-8311-9d200bc8891b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valmin = np.min([np.min(sin0probe), np.min(sin1probe), np.min(sin2probe)])\n",
+    "valmax = np.min([np.max(sin0probe), np.max(sin1probe), np.max(sin2probe)])\n",
+    "zeronorm = TwoSlopeNorm(vcenter=0, vmin=valmin, vmax=valmax)\n",
+    "\n",
+    "plt.figure(figsize=(21, 7))\n",
+    "plt.suptitle('Relative probe DM settings in Volts, for 1e-5 contrast')\n",
+    "\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.imshow(sin0probe, cmap='RdBu', origin='lower', norm=zeronorm)\n",
+    "plt.title('Cosine')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.imshow(sin1probe, cmap='RdBu', origin='lower', norm=zeronorm)\n",
+    "plt.title('Sine left-right')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.imshow(sin2probe, cmap='RdBu', origin='lower', norm=zeronorm)\n",
+    "plt.title('Sine up-down')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "734ed3ae-f4a9-49aa-a63a-dae9099a2d32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sin0probe.shape)\n",
+    "print(np.max(sin0probe))\n",
+    "print(np.argmax(sin0probe))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d36cd67-01ad-4542-ba03-efba86659a40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create single-actuator probes\n",
+    "act0probe = np.zeros(sin0probe.shape)\n",
+    "act0probe.ravel()[np.argmax(sin0probe)] = np.max(sin0probe)\n",
+    "\n",
+    "act1probe = np.zeros(sin0probe.shape)\n",
+    "act1probe.ravel()[np.argmax(sin0probe) + 1] = np.max(sin0probe)\n",
+    "\n",
+    "act2probe = np.zeros(sin0probe.shape)\n",
+    "act2probe.ravel()[np.argmax(sin0probe) + sin0probe.shape[0] + 1] = np.max(sin0probe)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cddc84c1-7a51-4ae4-9d42-06ce6148ee1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zeronorm = TwoSlopeNorm(vcenter=0, vmin=-np.max(act0probe), vmax=np.max(act0probe))\n",
+    "\n",
+    "plt.figure(figsize=(21, 7))\n",
+    "plt.suptitle('Relative probe DM settings in Volts, for ??? contrast')\n",
+    "\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.imshow(act0probe, cmap='RdBu', origin='lower', norm=zeronorm)\n",
+    "plt.title('0')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.imshow(act1probe, cmap='RdBu', origin='lower', norm=zeronorm)\n",
+    "plt.title('1')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.imshow(act2probe, cmap='RdBu', origin='lower', norm=zeronorm)\n",
+    "plt.title('2')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5aef6cf-d2e2-453e-b5b5-45f3c12b5112",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(act0probe + act1probe + act2probe, cmap='RdBu', origin='lower', norm=zeronorm)\n",
+    "plt.title('Overlapping single-actuator probes, to check relative location')\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13499029-0f1e-41a6-b52c-3f89ffba2ae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fits.writeto('narrowfov_dmrel_1.0e-05_act0.fits', act0probe, overwrite=True)\n",
+    "# fits.writeto('narrowfov_dmrel_1.0e-05_act1.fits', act1probe, overwrite=True)\n",
+    "# fits.writeto('narrowfov_dmrel_1.0e-05_act2.fits', act2probe, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7c21722-bccd-44ee-93e6-96b4ed4494a5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.23"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This just adds a useful notebook in @ivalaginja sandbox to create single-actuator probes files, so I think we could merge that in so it's easier to pick-up. 