### PR TITLE
Only deploy docs on push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,10 +18,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
     - uses: actions/checkout@v4
 
@@ -38,17 +34,25 @@ jobs:
       run: |
         cd docs
         make html
-    
+
+  deploy_docs:
+    name: Deploy
+    if: github.event_name == 'push'
+    needs: build_docs
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
     - name: Setup Pages
-      if: github.event_name == 'push'
       uses: actions/configure-pages@v4
-      
+
     - name: Upload to GitHub Pages
-      if: github.event_name == 'push'
       uses: actions/upload-pages-artifact@v3
       with:
         path: ./docs/build/html
 
     - name: Deploy to GitHub Pages
-      if: github.event_name == 'push'
       uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fixes #72.

Our previous job does Pages upload + deploy, which we typically only want on push to main. On PR events, GITHUB_TOKEN won’t have the needed permissions and the Pages deploy can fail or be blocked, which seems to be the case for us.

The usual pattern is:
- PRs: build docs only (to satisfy the required “Build” status check)
- Push to main: build + upload + deploy to Pages

In this PR, I change the workflow to build the docs on "ready for review", but it only deploys the docs when the PR is merged.