### PR TITLE
Fix pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,14 @@ jobs:
       run: |
         cd docs
         make html
+        ls -la build/html
+
+    # Upload only for push-to-main runs (deployment pipeline)
+    - name: Upload Pages artifact
+      if: github.event_name == 'push'
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: docs/build/html
 
   deploy_docs:
     name: Deploy
@@ -41,18 +49,15 @@ jobs:
     needs: build_docs
     runs-on: ubuntu-latest
 
+    permissions:
+      pages: write
+      id-token: write
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-
-    - name: Upload to GitHub Pages
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: ./docs/build/html
-
     - name: Deploy to GitHub Pages
+      id: deployment
       uses: actions/deploy-pages@v4


### PR DESCRIPTION
On the current push-to-main run, when actions/upload-pages-artifact executes, the directory `./docs/build/html` doesn’t exist in that job’s workspace and the docs deployment fails even if the build during PR preparation worked out. This is likely because the build ran in a different job, and we are trying to upload in another job without rebuilding or passing artifacts.

This PR fixes this by uploading the Pages artifact in the same job that builds the docs (the build job), and makes sure it’s gated to push. Then deploy just deploys that artifact.

We can probably only test this by merging the PR.