### PR TITLE
Update run_corgisim_nulling_gitl.py to use EETC if using noisy images

### DIFF
--- a/corgihowfsc/scripts/run_corgisim_nulling_gitl.py
+++ b/corgihowfsc/scripts/run_corgisim_nulling_gitl.py
@@ -101,13 +101,18 @@ def main():
     elif backend_type == 'corgihowfsc':
         crop_params['lrow'] = 0
         crop_params['lcol'] = 0  
-        normalization_strategy = CorgiNormalization(cfg,
-                                                cstrat,
-                                                hconf,
-                                                cor=args.mode,
-                                                corgi_overrides=corgi_overrides,
-                                                separation_lamD=7,
-                                                exptime_norm=0.01)
+
+        # Use EETC if using noisy images
+        if corgi_overrides['is_noise_free'] == False:
+            normalization_strategy = EETCNormalization()
+        else:
+            normalization_strategy = CorgiNormalization(cfg,
+                                                    cstrat,
+                                                    hconf,
+                                                    cor=args.mode,
+                                                    corgi_overrides=corgi_overrides,
+                                                    separation_lamD=7,
+                                                    exptime_norm=0.01)
 
     nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg, args, hconf, modelpath, jacfile, probefiles, n2clistfiles, crop_params, dmstartmaps)
 


### PR DESCRIPTION
Should be using EETC if using flight-like images. With current version of corgisim, it seems to be ok and not saturating.

<img width="1227" height="475" alt="image" src="https://github.com/user-attachments/assets/81e465b3-9b1d-465b-a989-e51ef37b8de2" />


