### PR TITLE
Fixing the bug of passing strings instead of number

### DIFF
--- a/corgihowfsc/gitl/nulling_gitl.py
+++ b/corgihowfsc/gitl/nulling_gitl.py
@@ -102,6 +102,7 @@ def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg,
     precomp = args.precomp
     num_process = args.num_process
     num_threads = args.num_threads
+    contrast = float(args.starting_contrast) # "starting" value to bootstrap getting we0
 
     safe_cpu_count = args.num_imager_worker # TODO - hard coding
     print('Using num_imager_worker = ', safe_cpu_count)
@@ -160,9 +161,6 @@ def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg,
         logging.basicConfig(level=logging.INFO)
         pass
     log = logging.getLogger(__name__)
-
-
-    contrast = args.starting_contrast # "starting" value to bootstrap getting we0
 
     # dm1_list, dm2
     # Get DM lists


### PR DESCRIPTION
## Description

<!-- Provide a general summary of your changes in the title above. Also indicate which issue this PR is solving, if applicable. -->

The last merge introduces a bug that would crash the nulling_gitl due the type mismatch: 
args.starting_contrast is passing in string instead of float into ` unprobed_snr = cstrat.get_unprobedsnr(1, contrast)`. 

Now we force the `args.starting_contrast` to be a float at the start of the loop: 
`contrast = float(args.starting_contrast)`

These tasks should be finished before this PR is ready for review:

- [ ]

## Checklist

Only check the ones that apply.

- [ ] Show contrast convergence plot of three iterations with compact model
- [ ] Show contrast convergence plot of three iterations with corgisim model
- [ ] Added screenshots of expected results or test results on this PR
