### PR TITLE
Update to Corgisim-specific CGISim installation

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -23,7 +23,7 @@ Download these files manually by clicking on the following links and save them t
 
 Navigate to a directory where you want to clone the following three repositories, then clone them:  
 - CGI-EETC repo
-- the repo containing the CPP-specific CGISim Roman preflight model to use with Corgisim (*not* the official model from Sourceforge)
+- the repo containing the CPP-specific CGISim Roman preflight model to use with Corgisim (overrides the official model from Sourceforge)
 - this repo, CorgiSim-howfsc
 
 ```bash

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -21,10 +21,14 @@ Download these files manually by clicking on the following links and save them t
 
 ### 2. Clone required repositories
 
-Navigate to a directory where you want to clone the repositories, then clone the CGI-EETC repo and this repo, CorgiSim-howfsc:
+Navigate to a directory where you want to clone the following three repositories, then clone them:  
+- CGI-EETC repo
+- the repo containing the CPP-specific CGISim Roman preflight model to use with Corgisim (*not* the official model from Sourceforge)
+- this repo, CorgiSim-howfsc
 
 ```bash
 git clone https://github.com/nasa-jpl/cgi-eetc.git
+git clone https://github.com/roman-corgi/cgisim_cpp.git
 git clone https://github.com/roman-corgi/corgihowfsc.git
 ````
 
@@ -51,15 +55,26 @@ python setup_cgi_packages.py C:\Users\username\Downloads\
 python setup_cgi_packages.py /home/user/cgi-files/
 ```
 
-### 4. Get large files and install cgi-eetc
+### 4. Install the Roman model done with CGISim (Corgisim-specific) from the local clone
+
+:::{note}
+This installation only finishes correctly if PROPER has been installed before, which is done in step 3 above by calling `setup_cgi_packages.py`.
+:::
 
 ```bash
-cd cgi-eetc
+cd ../cgisim_cpp
+pip install -e .
+```
+
+### 5. Get large files and install cgi-eetc
+
+```bash
+cd ../cgi-eetc
 git lfs pull
 pip install -e .
 ```
 
-### 5. Optional: Install cgi-howfsc in editable mode for development
+### 6. Optional: Install cgi-howfsc in editable mode for development
 
 ```bash
 pip uninstall howfsc
@@ -68,7 +83,7 @@ cd cgi-howfsc
 pip install -e .
 ```
 
-### 6. Verify Installation
+### 7. Verify Installation
 Test that everything is installed correctly:
 
 ```python
@@ -113,7 +128,7 @@ If you encounter an error like this:
 ```bash
 OSError: No SIMPLE card found, this file does not appear to be a valid FITS file. If this is really a FITS file, try with ignore_missing_simple=True
 ```
-you are probably missing the LFS files from cgi-eetc.
+you are probably missing the LFS files from `cgi-eetc`.
 
 To fix this...
 - Make sure you have Git LFS installed: https://git-lfs.github.com/


### PR DESCRIPTION
## Description
Since `corgihowfsc` uses the Corgisim optical model, it needs to fulfill [Corgisim](https://github.com/roman-corgi/corgisim) dependency requirements. One of them is to use the Corgisim-compatible CGISim model found here: https://github.com/roman-corgi/cgisim_cpp, instead of the official version from Sourceforge. This PR updates the installation instructions and scripts to reflect that.

## Checklist

Only check the ones that apply.

- [x] Show contrast convergence plot of three iterations with compact model
- [x] Show contrast convergence plot of three iterations with corgisim model
- [ ] Added screenshots of expected results or test results on this PR
