### PR TITLE
Kickoff iterations

### DIFF
--- a/corgihowfsc/gitl/nulling_gitl.py
+++ b/corgihowfsc/gitl/nulling_gitl.py
@@ -117,6 +117,69 @@ def apply_pmn_creep_and_hysteresis(flat_dm_filenames,add_creep,add_hysteresis,dm
     dmstartmaps_adjusted = [dm1_adjusted,dm2_adjusted]
     return dmstartmaps_adjusted
 
+def calculate_Z6(x,y,c=1):
+    '''
+    Calculate the focus at a point (x,y) in Cartesian coordinates, multiplied
+    by the scale factor c.
+    
+    Parameters:
+    ----------
+    x: x coordinate (normalized to a max of 1)
+    y: y coordinate (normalized to a max of 1)
+    c: scale factor
+    
+    Returns:
+    -------
+    Z6: the calculated focus
+    Z6(rho,theta) = c*sqrt(6)*rho**2*cos(2*theta)
+    '''
+    # Step 1: Convert (x,y) to (rho,theta)
+    rho = np.sqrt(x**2 + y**2)
+    theta = np.atan2(y,x)
+    
+    # Step 2: Calculate Z6
+    Z6 = c * np.sqrt(6) * rho**2 * np.cos(2*theta)
+    
+    return Z6
+
+def apply_Z6_to_DM(dm_num,nm):
+    '''
+    Calculate the voltage map that applies astigmatism to the selected dm.
+    
+    Parameters:
+    ----------
+    dm_num: scalar, 1 or 2 to identify the DM
+    nm: float, how many nm of astigmatism to apply
+    
+    Returns:
+    --------
+    Z6_voltages: voltage map that applies astigmatism to the dm.
+    '''
+    # Step 0: Set the scale factor
+    if dm_num==1:
+        c = nm/3.6
+    elif dm_num==2:
+        c = nm/3.3
+        
+    # Step 1: Set up a 48x48 coordinate grid
+    n = np.arange(0,48).reshape(1,48)
+    dx = 2/48
+    xvt = (n-24+1/2)*dx
+    dy = 2/48
+    yvt = (n-24+1/2)*dy
+    (X,Y) = np.meshgrid(xvt,yvt)
+    
+    # Step 2: Calculate Z6 voltages for points within a circle of radius 1
+    Z6_voltages = np.zeros((48,48))
+    for ii in range(48):
+        for jj in range(48):
+            if X[ii,jj]**2 + Y[ii,jj]**2 > 1:
+                Z6_voltages[ii,jj] = 0
+            else:
+                Z6_voltages[ii,jj] = calculate_Z6(X[ii,jj], Y[ii,jj],c)
+                
+    return Z6_voltages
+    
 
 def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg, args, hconf, modelpath, jacfile, probefiles, n2clistfiles, crop_params, dmstartmaps, metadata=None, output_every_iter=True, output_model_efield=True):
     """Run a nulling sequence, using the compact optical model as the data source.
@@ -182,6 +245,10 @@ def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg,
     apply_hysteresis = args.apply_hysteresis
     if apply_hysteresis == True:
         previous_dmstartmap_filenames = args.previous_dmstartmap_filenames
+    add_Z6_to_DM1 = args.add_Z6_to_DM1
+    DM1_Z6_nm = args.DM1_Z6_nm
+    add_Z6_to_DM2 = args.add_Z6_to_DM2
+    DM2_Z6_nm = args.DM2_Z6_nm
 
     safe_cpu_count = args.num_imager_worker 
     print('Using num_imager_worker = ', safe_cpu_count)
@@ -243,6 +310,18 @@ def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg,
             print('Applying PMN creep and DM hysteresis')
             
         dmstartmaps_adjusted = apply_pmn_creep_and_hysteresis(flat_dm_filenames,apply_creep,apply_hysteresis,dmstartmaps,previous_dmstartmap_filenames)
+        dm1_list, dm2_list , _, _, _ = probes.get_dm_probes(cfg,probefiles,dmstartmaps_adjusted)
+    else:
+        dmstartmaps_adjusted = dmstartmaps
+    
+    # Add Z6 to DM1 and DM2 if appropriate
+    if add_Z6_to_DM1 == True:
+        Z6_voltages = apply_Z6_to_DM(1, DM1_Z6_nm)
+        dmstartmaps_adjusted[0] = dmstartmaps_adjusted[0]+Z6_voltages
+        dm1_list, dm2_list , _, _, _ = probes.get_dm_probes(cfg,probefiles,dmstartmaps_adjusted)
+    if add_Z6_to_DM2 == True:
+        Z6_voltages = apply_Z6_to_DM(2, DM2_Z6_nm)
+        dmstartmaps_adjusted[1] = dmstartmaps_adjusted[1] + Z6_voltages
         dm1_list, dm2_list , _, _, _ = probes.get_dm_probes(cfg,probefiles,dmstartmaps_adjusted)
         
     nlam = len(cfg.sl_list)

--- a/corgihowfsc/gitl/nulling_gitl.py
+++ b/corgihowfsc/gitl/nulling_gitl.py
@@ -45,10 +45,77 @@ from corgihowfsc.utils.gitl_worker import _collect_framelist
 from corgihowfsc.gitl.gitl_funcs import get_initial_cam_params
 from corgihowfsc.utils.metrics import get_ni
 
+from astropy.io import fits
+
 
 eetc_path = os.path.dirname(os.path.abspath(eetc.__file__))
 howfscpath = os.path.dirname(os.path.abspath(howfsc.__file__))
 defjacpath = os.path.join(os.path.dirname(howfscpath), 'jacdata')
+
+def apply_pmn_creep_and_hysteresis(flat_dm_filenames,add_creep,add_hysteresis,dmstartmaps,previous_dmstartmap_filenames=None):
+    '''
+    Apply PMN creep and DM hysteresis to the DM voltage maps
+    PMN creep is modeled as a scale factor afffecting the actuator voltages
+    DM hysteresis is modeled as 1% of the difference between the new pattern and
+    the previous one, added to the new pattern
+
+    Parameters
+    ----------
+    flat_dm_filenames: list of strings
+        Two-element list providing the paths to the flat patterns for dm1 and dm2
+    add_creep : Boolean
+        Determines whether to add creep (true) or not (false)
+    add_hysteresis : Boolean
+        Determines whether to add hysteresis (true) or not (false)
+    dmstartmaps : list of ndarray
+        Two-element list [dm1, dm2] giving the absolute starting DM
+        commands in volts.
+    previous_dmstartmap_filenames: optional list of ndarray (if applying hysteresis)
+        Two-element list [previous_dm1_startmap_filename,previous_dm2_startmap_filename]
+        giving the names of the files containing the previous dmstartmaps
+        
+    Returns
+    -------
+    dmstartmaps_adjusted: list of ndarray
+        Two-element list [dm1_adjusted,dm2_adjusted] giving the starting DM commands in volts,
+        modified by the creep and/or hysteresis
+
+    '''
+    # Step 0: Load the HLC flats
+    flat_dm1 = fits.getdata(flat_dm_filenames[0])
+    flat_dm2 = fits.getdata(flat_dm_filenames[1])
+    
+    # For now, the creep is modeled as a multiplicative scale factor, fixed at 371/390
+    if add_creep == True:
+        creep_factor = 371/390
+    else:
+        creep_factor = 1
+    
+    # DM hysteresis is modeled as 1% of the change from the previous voltage pattern,
+    # added to the current pattern
+    if add_hysteresis == True:
+        
+        # Step 1: Load the previous dmstartmaps
+        previous_dm1_startmap = fits.getdata(previous_dmstartmap_filenames[0])
+        previous_dm2_startmap = fits.getdata(previous_dmstartmap_filenames[1])
+    
+        # Step 2: Calculate the delta voltages for each dm
+        dm1_delta = dmstartmaps[0] - previous_dm1_startmap
+        dm2_delta = dmstartmaps[1] - previous_dm2_startmap
+        
+    else:
+        dm1_delta = 0
+        dm2_delta = 0
+        
+    # Calculate the adjusted voltage patterns
+    deltadm1_from_flat = dmstartmaps[0] - flat_dm1
+    deltadm2_from_flat = dmstartmaps[1] - flat_dm2
+    
+    dm1_adjusted = flat_dm1 + creep_factor*deltadm1_from_flat - 0.01*dm1_delta
+    dm2_adjusted = flat_dm2 + creep_factor*deltadm2_from_flat - 0.01*dm2_delta
+    
+    dmstartmaps_adjusted = [dm1_adjusted,dm2_adjusted]
+    return dmstartmaps_adjusted
 
 
 def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg, args, hconf, modelpath, jacfile, probefiles, n2clistfiles, crop_params, dmstartmaps, metadata=None, output_every_iter=True, output_model_efield=True):
@@ -110,6 +177,11 @@ def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg,
     num_threads = args.num_threads
     contrast = float(args.starting_contrast) # "starting" value to bootstrap getting we0
     debug = args.debug
+    flat_dm_filenames = args.flat_dm_filenames
+    apply_creep = args.apply_creep
+    apply_hysteresis = args.apply_hysteresis
+    if apply_hysteresis == True:
+        previous_dmstartmap_filenames = args.previous_dmstartmap_filenames
 
     safe_cpu_count = args.num_imager_worker 
     print('Using num_imager_worker = ', safe_cpu_count)
@@ -161,6 +233,18 @@ def nulling_gitl(cstrat, estimator, probes, normalization_strategy, imager, cfg,
     # dm1_list, dm2_list
     # Get DM lists
     dm1_list, dm2_list, dmrel_list, dm10, dm20 = probes.get_dm_probes(cfg, probefiles, dmstartmaps)
+    if (apply_creep == True) or (apply_hysteresis == True):
+        if (apply_creep == True) and (apply_hysteresis != True):
+            print('Applying PMN creep')
+            previous_dmstartmap_filenames = None
+        elif (apply_creep != True) and (apply_hysteresis == True):
+            print('Applying DM hysteresis')
+        elif (apply_creep == True) and (apply_hysteresis == True):
+            print('Applying PMN creep and DM hysteresis')
+            
+        dmstartmaps_adjusted = apply_pmn_creep_and_hysteresis(flat_dm_filenames,apply_creep,apply_hysteresis,dmstartmaps,previous_dmstartmap_filenames)
+        dm1_list, dm2_list , _, _, _ = probes.get_dm_probes(cfg,probefiles,dmstartmaps_adjusted)
+        
     nlam = len(cfg.sl_list)
     ndm = 2 * len(dmrel_list) + 1
     nprobepair = len(dmrel_list)

--- a/corgihowfsc/model/nfov_band1/nfov_band1_360deg/cstrat_nfov_band1.yaml
+++ b/corgihowfsc/model/nfov_band1/nfov_band1_360deg/cstrat_nfov_band1.yaml
@@ -1,88 +1,154 @@
 regularization:
   -
     first: 1
+    last: 3
+    low: 0
+    high: 1.0e-5
+    value: -4.5
+  -
+    first: 4
     last: 4
     low: 0
     high: 1.0e-5
-    value: -2.0
+    value: -4.5
   -
     first: 5
-    last: 5
-    low: 0
-    high: 1.0e-5
-    value: -5.0
-  -
-    first: 6
-    last: 9
-    low: 0
-    high: 1.0e-5
-    value: -2.0
-  -
-    first: 10
     last: 10
     low: 0
     high: 1.0e-5
-    value: -5.0
+    value: -4.5
   -
     first: 11
-    last: 14
+    last: 11
     low: 0
     high: 1.0e-5
-    value: -2.0
+    value: -6.0
   -
-    first: 15
-    last: 15
+    first: 12
+    last: 16
     low: 0
     high: 1.0e-5
-    value: -5.0
+    value: -3.5
   -
-    first: 16
-    last: 19
+    first: 17
+    last: 17
     low: 0
     high: 1.0e-5
-    value: -2.0
+    value: -6.0
   -
-    first: 20
-    last: 20
+    first: 18
+    last: 22
     low: 0
     high: 1.0e-5
-    value: -5.0
+    value: -3.5
   -
-    first: 21
-    last: 24
+    first: 23
+    last: 23
     low: 0
     high: 1.0e-5
-    value: -2.0
+    value: -6.0
   -
-    first: 25
-    last: 25
+    first: 24
+    last: 28
     low: 0
     high: 1.0e-5
-    value: -5.0
+    value: -3.5
   -
-    first: 26
+    first: 29
     last: 29
     low: 0
     high: 1.0e-5
-    value: -3.0
+    value: -6.0
   -
     first: 30
-    last: 30
+    last: 34
     low: 0
     high: 1.0e-5
-    value: -5.0
+    value: -3.5
   -
-    first: 31
+    first: 35
+    last: 35
+    low: 0
+    high: 1.0e-5
+    value: -6.5
+  -
+    first: 36
+    last: 40
+    low: 0
+    high: 1.0e-5
+    value: -3.5
+  -
+    first: 41
+    last: 41
+    low: 0
+    high: 1.0e-5
+    value: -6.5
+  -
+    first: 42
+    last: 46
+    low: 0
+    high: 1.0e-5
+    value: -3.5
+  -
+    first: 47
+    last: 47
+    low: 0
+    high: 1.0e-5
+    value: -6.5
+  -
+    first: 48
+    last: 52
+    low: 0
+    high: 1.0e-5
+    value: -3.5
+  -
+    first: 53
+    last: 53
+    low: 0
+    high: 1.0e-5
+    value: -6.5
+  -
+    first: 54
+    last: 58
+    low: 0
+    high: 1.0e-5
+    value: -3.5
+  -
+    first: 59
+    last: 59
+    low: 0
+    high: 1.0e-5
+    value: -6.5
+  -
+    first: 60
+    last: 64
+    low: 0
+    high: 1.0e-5
+    value: -3.5
+  -
+    first: 65
+    last: 65
+    low: 0
+    high: 1.0e-5
+    value: -6.5
+  -
+    first: 66
+    last: 75
+    low: 0
+    high: 1.0e-5
+    value: -3.5
+  -
+    first: 76
     last: None
     low: 0
     high: 1.0e-5
-    value: -3.0
+    value: -3.5
   -
     first: 1
     last: None
     low: 1.0e-5
     high: None
-    value: -2.0
+    value: -3.5
 
 pixelweights:
   -

--- a/corgihowfsc/scripts/run_corgisim_nulling_gitl.py
+++ b/corgihowfsc/scripts/run_corgisim_nulling_gitl.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import matplotlib
 import argparse
 
-matplotlib.use('TkAgg') #Agg
+#matplotlib.use('TkAgg') #Agg
 
 import eetc
 from howfsc.control.cs import ControlStrategy
@@ -21,6 +21,8 @@ from corgihowfsc.utils.contrast_nomalization import CorgiNormalization, EETCNorm
 from corgihowfsc.gitl.nulling_gitl import nulling_gitl
 from corgihowfsc.utils.corgisim_gitl_frames import GitlImage
 from corgihowfsc.utils.output_management import make_output_file_structure
+
+import numpy as np
 
 eetc_path = os.path.dirname(os.path.abspath(eetc.__file__))
 howfscpath = os.path.dirname(os.path.abspath(corgihowfsc.__file__))
@@ -45,6 +47,8 @@ def main(param_file_name='default_param.yml', fullpath=False):
 
     cmd_args = parser.parse_args()
     param_file = os.path.abspath(os.path.expanduser(cmd_args.param_file))
+    # Verify this is the correct file
+    print('Using parameters from %s' % param_file)
 
     if not os.path.isfile(param_file):
         raise FileNotFoundError(f'Parameter file not found: {param_file}')
@@ -68,7 +72,12 @@ def main(param_file_name='default_param.yml', fullpath=False):
     mode = sim_settings['mode']
     dark_hole = sim_settings['dark_hole']
     probe_shape = sim_settings['probe_shape']
-
+    flat_dm_filenames = sim_settings['flat_dm_filenames']
+    apply_creep = sim_settings['apply_creep']
+    apply_hysteresis = sim_settings['apply_hysteresis']
+    if apply_hysteresis == True:
+        previous_dmstartmap_filenames = sim_settings['previous_dmstartmap_filenames']
+   
     # Backend specific settings - which imager model to use, normalisation strategy, and which dmstartmaps to use for the first iteration (if any)
     backend_type = model_cfg['backend_type']
     normalization_type = model_cfg['normalization_type']
@@ -145,7 +154,12 @@ def main(param_file_name='default_param.yml', fullpath=False):
     args.num_proper_process = num_proper_process
     args.use_mpi = use_mpi
     args.debug = debug
-
+    args.flat_dm_filenames = flat_dm_filenames
+    args.apply_creep = apply_creep
+    args.apply_hysteresis = apply_hysteresis
+    if apply_hysteresis == True:
+        args.previous_dmstartmap_filenames = previous_dmstartmap_filenames
+   
     os.environ.setdefault(
         'CORGIHOWFSC_IMAGE_DEBUG_CSV',
         os.path.join(os.path.dirname(args.logfile), 'image_worker_debug.csv'),
@@ -195,6 +209,7 @@ def main(param_file_name='default_param.yml', fullpath=False):
 
     if num_proper_process is not None:
         corgi_overrides['NCPUS'] = num_proper_process
+               
 
     # Initialise the workers with the necessary data and configuration to run the howfsc loop, including the model files and any overrides
     if mpi_comm is not None:
@@ -220,8 +235,7 @@ def main(param_file_name='default_param.yml', fullpath=False):
         hconf=hconf,  # Your host config with stellar properties
         backend=backend_type,
         cor=mode,
-        corgi_overrides=corgi_overrides
-    )
+        )
 
     # Estimator selection
     if model_cfg['estimator'] == 'perfect':
@@ -268,6 +282,8 @@ def main(param_file_name='default_param.yml', fullpath=False):
         "dark_hole": args.dark_hole,
         "probe_shape": args.probe_shape,
         "precomp": args.precomp,
+        "apply_creep": args.apply_creep,
+        "apply_hysteresis": args.apply_hysteresis,
         # --- runtime ---
         "num_process": args.num_process,
         "num_threads": args.num_threads,
@@ -319,4 +335,5 @@ def main(param_file_name='default_param.yml', fullpath=False):
 
 
 if __name__ == '__main__':
-    main()
+    param_file_name='/Users/jessicag/Documents/GitHub/Dev/corgihowfsc/sandbox/jag/kickoff_iterations_params.yml'
+    main(param_file_name = param_file_name)

--- a/corgihowfsc/scripts/run_corgisim_nulling_gitl.py
+++ b/corgihowfsc/scripts/run_corgisim_nulling_gitl.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import matplotlib
+import matplotlib.pyplot as plt
 import argparse
 
 #matplotlib.use('TkAgg') #Agg
@@ -77,6 +78,12 @@ def main(param_file_name='default_param.yml', fullpath=False):
     apply_hysteresis = sim_settings['apply_hysteresis']
     if apply_hysteresis == True:
         previous_dmstartmap_filenames = sim_settings['previous_dmstartmap_filenames']
+    add_Z6_to_DM1 = sim_settings['add_Z6_to_DM1']
+    if add_Z6_to_DM1 == True:
+        DM1_Z6_nm = sim_settings['DM1_Z6_nm']
+    add_Z6_to_DM2 = sim_settings['add_Z6_to_DM2']
+    if add_Z6_to_DM2 == True:
+        DM2_Z6_nm = sim_settings['DM2_Z6_nm']
    
     # Backend specific settings - which imager model to use, normalisation strategy, and which dmstartmaps to use for the first iteration (if any)
     backend_type = model_cfg['backend_type']
@@ -159,7 +166,10 @@ def main(param_file_name='default_param.yml', fullpath=False):
     args.apply_hysteresis = apply_hysteresis
     if apply_hysteresis == True:
         args.previous_dmstartmap_filenames = previous_dmstartmap_filenames
-   
+    args.add_Z6_to_DM1 = add_Z6_to_DM1
+    args.DM1_Z6_nm = DM1_Z6_nm if add_Z6_to_DM1==True else None
+    args.add_Z6_to_DM2 = add_Z6_to_DM2
+    args.DM2_Z6_nm = DM2_Z6_nm if add_Z6_to_DM2==True else None
     os.environ.setdefault(
         'CORGIHOWFSC_IMAGE_DEBUG_CSV',
         os.path.join(os.path.dirname(args.logfile), 'image_worker_debug.csv'),
@@ -284,6 +294,11 @@ def main(param_file_name='default_param.yml', fullpath=False):
         "precomp": args.precomp,
         "apply_creep": args.apply_creep,
         "apply_hysteresis": args.apply_hysteresis,
+        "previous_dmstartmap_filenames": args.previous_dmstartmap_filenames if args.apply_hysteresis==True else None,
+        "add_Z6_to_DM1": args.add_Z6_to_DM1,
+        "DM1_Z6_nm": args.DM1_Z6_nm if args.add_Z6_to_DM1==True else None,
+        "add_Z6_to_DM2": args.add_Z6_to_DM2,
+        "DM2_Z6_nm": args.DM2_Z6_nm if args.add_Z6_to_DM2==True else None,
         # --- runtime ---
         "num_process": args.num_process,
         "num_threads": args.num_threads,

--- a/corgihowfsc/scripts/run_nulling_gitl.py
+++ b/corgihowfsc/scripts/run_nulling_gitl.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import matplotlib
-matplotlib.use('TkAgg')
+#matplotlib.use('TkAgg')
 
 import eetc
 from howfsc.control.cs import ControlStrategy

--- a/sandbox/jag/CompareRunResults.py
+++ b/sandbox/jag/CompareRunResults.py
@@ -1,0 +1,114 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+import re
+from astropy.io import fits
+from corgisim import scene, instrument
+
+plt.rcParams.update({'font.size': 14})
+
+import roman_preflight_proper
+
+roman_preflight_proper.copy_here()
+
+comparison = 'Individual'   
+                            # Options:  'LSandFSAM' to look at the tiny differences the signs cause
+                            #           'Individual' to look at each of the effects on its own
+                            #           'LeastSignificantErrors' to look at the effects that have the least impact
+                            #           'MostSignificantErrors' to look at the errors that have the most impact
+                            #           'Star_on_FSM_options' to compare options for the star on FPM alignment (~2.7 mas) (doesn't really make any difference)
+
+if comparison == 'LSandFSAM':
+    folder_names = {
+        'LS++,FS++' : 's26_AlltoDate_LS++_FS++/2026-06-18_183437_corgisim_model',
+        'LS++,FS+-' : 's26.1_AlltoDate_LS++_FS+-/2026-06-18_192216_corgisim_model',
+        'LS++,FS-+' : 's26.2_AlltoDate_LS++_FS-+/2026-06-18_201228_corgisim_model',
+        'LS++,FS--' : 's26.3_AlltoDate_LS++_FS--/2026-06-18_205952_corgisim_model',
+        'LS+-,FS++' : 's26.4_AlltoDate_LS+-_FS++/2026-06-19_085727_corgisim_model',
+        'LS+-,FS+-' : 's26.5_AlltoDate_LS+-_FS+-/2026-06-19_095555_corgisim_model',
+        'LS+-,FS-+' : 's26.6_AlltoDate_LS+-_FS-+/2026-06-19_104955_corgisim_model',
+        'LS+-,FS--' : 's26.7_AlltoDate_LS+-_FS--/2026-06-19_115117_corgisim_model'
+        }
+elif comparison == 'Individual':
+    folder_names = {
+        #'All errors combined': 's26_AlltoDate_LS++_FS++/2026-06-18_183437_corgisim_model',
+        'All errors combined': 's29_AlltoDate/2026-06-29_101445_corgisim_model',
+        'PMN Creep': 's2_Creep_without_beta_bumping/2026-05-22_085333_corgisim_model',
+        'DM Hysteresis' : 's3_Hysteresis_without_beta_bumping/2026-05-22_094445_corgisim_model',
+        '30 nm Focus on primary': 's6_30nmFocus_only/2026-06-08_134629_corgisim_model',
+        '2.5 nm Z6 on DM1': 's8_Z6onDM1/2026-06-16_131553_corgisim_model',
+        '2.5 nm Z6 on DM2': 's9_Z6onDM2/2026-06-16_140239_corgisim_model',
+        'LS Misalignment': 's13_LSmisalignment_++/2026-06-18_131144_corgisim_model',
+        'FSAM Misalignment': 's22_FieldStopMisalignment_++/2026-06-17_204726_corgisim_model',
+        '~2.7 mas Source shift': 's27.2_SourceShift_+x_+y/2026-06-25_142718_corgisim_model',
+        'No errors' : 's0_perfect/2026-06-16_121105_corgisim_model'
+        }
+elif comparison == 'LeastSignificantErrors':
+    folder_names = {
+        'DM Hysteresis' : 's3_Hysteresis_without_beta_bumping/2026-05-22_094445_corgisim_model',
+        '30 nm Focus on primary': 's6_30nmFocus_only/2026-06-08_134629_corgisim_model',
+        'LS Misalignment': 's13_LSmisalignment_++/2026-06-18_131144_corgisim_model',
+        'FSAM Misalignment': 's22_FieldStopMisalignment_++/2026-06-17_204726_corgisim_model',
+        'Perfect case' : 's0_perfect/2026-06-16_121105_corgisim_model'
+        }
+elif comparison == 'MostSignificantErrors':
+    folder_names = {
+        'PMN Creep': 's2_Creep_without_beta_bumping/2026-05-22_085333_corgisim_model',
+        '2.5 nm Z6 on DM1': 's8_Z6onDM1/2026-06-16_131553_corgisim_model',
+        '2.5 nm Z6 on DM2': 's9_Z6onDM2/2026-06-16_140239_corgisim_model',
+        '2.5 nm Z6 on DM1 and DM2': 's10_Z6onDM1and2_only/2026-06-16_145736_corgisim_model',
+        'PMN Creen and 2.5 nm Z6 on DM1 and DM2':'s11_Z6onDM1and2_Creep/2026-06-16_155213_corgisim_model',
+        'All errors considered to date': 's26_AlltoDate_LS++_FS++/2026-06-18_183437_corgisim_model'
+        }
+elif comparison == 'Star_on_FSM_options':
+    folder_names = {
+        'source shift x':'s27.0_SourceShiftx/2026-06-25_105057_corgisim_model',
+        'source shift y':'s27.1_SourceShifty/2026-06-25_123421_corgisim_model',
+        'source shift +x +y':'s27.2_SourceShift_+x_+y/2026-06-25_142718_corgisim_model',
+        'source shift +x -y':'s27.3_SourceShift_+x_-y/2026-06-25_152014_corgisim_model',
+        'FPM shift x':'s28.0_FPMshiftx/2026-06-26_140254_corgisim_model',
+        'FPM shift y':'s28.1_FPMshifty/2026-06-26_145856_corgisim_model',
+        'FPM shift +x +y':'s28.2_FPMshift_+x_+y/2026-06-26_155046_corgisim_model',
+        'FPM shift +x -y':'s28.3_FPMshift_+x_-y/2026-06-26_163932_corgisim_model'}
+
+
+home_path = os.path.join('/Users/jessicag','corgiloop_data/corgi-howfsc_gitl')
+
+base_paths = {}
+for key in folder_names.keys():
+    base_paths[key] = os.path.join(home_path, folder_names[key])
+
+
+cmap = plt.get_cmap("tab20b")
+linestyles = ["-", "--", "-.", ":"]
+
+fig, ax = plt.subplots(figsize=(9, 5))
+
+for i, (label, base_path) in enumerate(base_paths.items()):
+    base = os.path.normpath(base_path)
+    csv_path = os.path.join(base, "measured_contrast.csv")
+
+    if not os.path.isfile(csv_path):
+        print(f"WARNING: not found – {csv_path}")
+        continue
+
+    contrast = pd.read_csv(csv_path, skiprows=1, header=None).squeeze()
+    iters = np.arange(len(contrast))+1
+
+    ax.plot(iters, contrast, marker="o", markersize=3, linewidth=1.5,
+            color=cmap(i / max(len(base_paths) - 1, 1)),
+            linestyle=linestyles[i % len(linestyles)],
+            label=label)
+
+ax.set_xlabel("Iteration")
+ax.set_ylabel("Measured Contrast")
+ax.set_title("Measured Contrast vs. Iteration (HLC B1)\ncorgihowfsc full model PWP estimator")
+ax.set_yscale("log")
+ax.set_xlim([0,11])
+ax.grid(True, which="both", alpha=0.3)
+# ax.legend(fontsize=14, loc="upper right")
+ax.legend(fontsize=14, loc="upper left", bbox_to_anchor=(1, 1), borderaxespad=0)
+plt.tight_layout()
+plt.show()
+

--- a/sandbox/jag/kickoff_iterations_params.yml
+++ b/sandbox/jag/kickoff_iterations_params.yml
@@ -1,0 +1,89 @@
+active_model: "corgihowfsc" # choose from "cgi-howfsc" or "corgihowfsc". This will determine which imager model is used and which settings are applied to the imager initialization.
+
+runtime:
+  # PROPER processes inside each image worker.
+  # MPI: match this to --cpus-per-task.
+  num_proper_process: 5 
+
+  # Local only: Jacobian worker processes. Ignored in MPI mode.
+  num_jac_process: 6 
+
+  # Local: image worker processes; null means serial image generation.
+  # MPI: active worker ranks; usually total MPI ranks minus 1 manager.
+  num_imager_worker: 4
+
+  # false: local run; true: MPI manager-worker run.
+  use_mpi: false 
+
+  # Extra logs/debug outputs; MPI also writes per-rank worker logs.
+  debug: false
+
+sim_settings:
+  loop_framework: "corgi-howfsc" # do not modify 
+  precomp: "precomp_jacs_always" # options: 'precomp_jacs_always', 'precomp_all_once', 'load_all' (only if defjacpath is not None)
+  output_every_iter: true # whether to save the output frames at every iteration (true) or after all iterations are done (false)
+  niter: 10 # number of iterations to run
+  mode: "nfov_band1" # options: see models
+  dark_hole: "360deg"  # options: see models
+  probe_shape: "default"
+  flat_dm_filenames:
+      - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm1_v.fits"
+      - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm2_v.fits"
+  apply_creep: true # options: apply PMN creep to the voltage maps (true) or not (false or None) 
+  apply_hysteresis: true # options: apply hysteresis to the voltage maps (true) or not (false or None)
+  previous_dmstartmap_filenames:
+      - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/spc-wide_ni_2e-8_dm1_v.fits"
+      - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/spc-wide_ni_2e-8_dm2_v.fits"
+  apply_zernikes: true
+
+
+paths:
+  base_path: "~" # default to home directory, but user can change to a different path
+  base_corgiloop_path: "corgiloop_data" # this is the proposed default but can be changed
+  defjacpath: "temp" # this is the proposed default but can be changed, should be somewhere outside the repo if used
+  final_filename: "final_frames.fits" # this is the proposed default but can be changed
+  folder_tag: null # this is an optional string that will be appended to the folder name where results are saved
+
+path_overrides:
+  # Set any of these to an absolute path to override the mode-derived default.
+  # Leave as null to use the mode-derived path.
+  # Can also override defjacpath and dmstartmap_filenames by providing full paths
+  cfgfile: null
+  cstratfile: null
+  hconffile: null
+
+crop:
+  nrow: 153 # Do not modify
+  ncol: 153 # Do not modify
+
+# model-specific settings that will be used to initialize the imager (cgi-howfsc for compact model and corgihowfsc for full model).
+models: 
+  cgi-howfsc:
+    backend_type: "cgi-howfsc"
+    normalization_type: "eetc"
+    estimator: "default" # options are "perfect" and "default"; perfect estimator uses the model e-field for estimation, while default estimator uses the standard pairwise probing method
+    starting_contrast: 6e-10 # starting contrast value for dmstartmap_filenames; not actually used in compact model
+    dmstartmap_filenames: 
+    # Initial DM shape. Provide either:
+    # - two filenames relative to modelpath, or
+    # - two absolute paths.
+    # Mixed absolute/relative entries are not supported.
+      - "gitl_start_compact_dm1.fits"  # can provide full path including filename or just a filename if the file is located in the modelpath
+      - "gitl_start_compact_dm2.fits"  # can provide full path including filename or just a filename if the file is located in the modelpath
+    lrow: 436 # Do not modify
+    lcol: 436 # Do not modify
+
+  corgihowfsc:
+    backend_type: "corgihowfsc"
+    normalization_type: "corgisim-off-axis" # other options are "corgisim-off-axis" and "corgisim-on-axis"
+    estimator: "default" # options are "perfect" and "default"; perfect estimator uses the model e-field for estimation, while default estimator uses the standard pairwise probing method  
+    starting_contrast: 3.0e-8 # starting contrast value for dmstartmap_filenames; if changing starting DM maps update this value
+    dmstartmap_filenames:
+      - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_ni_3e-8_dm1_v.fits"  # can provide full path including filename or just a filename if the file is located in the modelpath
+      - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_ni_3e-8_dm2_v.fits"  # can provide full path including filename or just a filename if the file is located in the modelpath
+    lrow: 0 # Do not modify
+    lcol: 0 # Do not modify
+    corgi_overrides: 
+      # Parameters forwarded to GitlImage initialization
+      is_noise_free: true
+      oversampling_factor: 3 # always odd number

--- a/sandbox/jag/kickoff_iterations_params.yml
+++ b/sandbox/jag/kickoff_iterations_params.yml
@@ -29,8 +29,8 @@ sim_settings:
   flat_dm_filenames:
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm1_v.fits"
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm2_v.fits"
-  apply_creep: true # true # options: apply PMN creep to the voltage maps (true) or not (false or None) 
-  apply_hysteresis: true # true # options: apply hysteresis to the voltage maps (true) or not (false or None)
+  apply_creep: true # options: apply PMN creep to the voltage maps (true) or not (false or None) 
+  apply_hysteresis: true # options: apply hysteresis to the voltage maps (true) or not (false or None)
   previous_dmstartmap_filenames:
       # Only used if hysteresis applied
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/spc-wide_ni_2e-8_dm1_v.fits"
@@ -90,8 +90,14 @@ models:
       # Parameters forwarded to GitlImage initialization
       is_noise_free: true
       oversampling_factor: 3 # always odd number
-      # Parameters only needed if apply_zernikes is true above
+      # Parameters to add Z4 (focus) to primary
       zindex:
         - 4
       zval_m:
         - 3.0e-8
+      # Parameters to add LS misalignment
+      lyot_x_shift_m: 3.0e-7
+      lyot_y_shift_m: -3.0e-7
+      # Parameters to add FSAM misalignment
+      field_stop_x_offset_m: -3.0e-7
+      field_stop_y_offset_m: -3.0e-7

--- a/sandbox/jag/kickoff_iterations_params.yml
+++ b/sandbox/jag/kickoff_iterations_params.yml
@@ -29,14 +29,16 @@ sim_settings:
   flat_dm_filenames:
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm1_v.fits"
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm2_v.fits"
-  apply_creep: false # true # options: apply PMN creep to the voltage maps (true) or not (false or None) 
-  apply_hysteresis: false # true # options: apply hysteresis to the voltage maps (true) or not (false or None)
+  apply_creep: true # true # options: apply PMN creep to the voltage maps (true) or not (false or None) 
+  apply_hysteresis: true # true # options: apply hysteresis to the voltage maps (true) or not (false or None)
   previous_dmstartmap_filenames:
       # Only used if hysteresis applied
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/spc-wide_ni_2e-8_dm1_v.fits"
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/spc-wide_ni_2e-8_dm2_v.fits"
-  apply_zernikes: true
-
+  add_Z6_to_DM1: true # options: apply voltage pattern to model Z6 on DM1 (true) or not (false or None)
+  DM1_Z6_nm: 2.5 # How many nm of astigmatism (Z6) to add to DM1, only used if add_Z6_to_DM1 == True
+  add_Z6_to_DM2: true # options: apply voltage pattern to model Z6 on DM2 (true) or not (false or None)
+  DM2_Z6_nm: 2.5 # How many nm of astigmatism (Z6) to add to DM2, only used if add_Z6_to_DM2 == True
 
 paths:
   base_path: "~" # default to home directory, but user can change to a different path

--- a/sandbox/jag/kickoff_iterations_params.yml
+++ b/sandbox/jag/kickoff_iterations_params.yml
@@ -101,3 +101,12 @@ models:
       # Parameters to add FSAM misalignment
       field_stop_x_offset_m: -3.0e-7
       field_stop_y_offset_m: -3.0e-7
+      # TWO OPTIONS FOR CHECKING THE STAR ON FPM ALIGNMENT
+      # Option 1: Shift the source throughout the system (shifts at FPM and image) 
+      # Parameters for the x and y offsets in mas
+      source_x_offset_mas: 2.7
+      source_y_offset_mas: 2.7
+      # Option 2: Shift the FPM 
+      # Parameters for the x and y offsets in lambda/D
+      fpm_x_offset: 0
+      fpm_y_offset: 0

--- a/sandbox/jag/kickoff_iterations_params.yml
+++ b/sandbox/jag/kickoff_iterations_params.yml
@@ -29,9 +29,10 @@ sim_settings:
   flat_dm_filenames:
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm1_v.fits"
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/hlc_flat_wfe_dm2_v.fits"
-  apply_creep: true # options: apply PMN creep to the voltage maps (true) or not (false or None) 
-  apply_hysteresis: true # options: apply hysteresis to the voltage maps (true) or not (false or None)
+  apply_creep: false # true # options: apply PMN creep to the voltage maps (true) or not (false or None) 
+  apply_hysteresis: false # true # options: apply hysteresis to the voltage maps (true) or not (false or None)
   previous_dmstartmap_filenames:
+      # Only used if hysteresis applied
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/spc-wide_ni_2e-8_dm1_v.fits"
       - "/Users/jessicag/anaconda3/envs/corgiloop/lib/python3.12/site-packages/roman_preflight_proper/examples/spc-wide_ni_2e-8_dm2_v.fits"
   apply_zernikes: true
@@ -87,3 +88,8 @@ models:
       # Parameters forwarded to GitlImage initialization
       is_noise_free: true
       oversampling_factor: 3 # always odd number
+      # Parameters only needed if apply_zernikes is true above
+      zindex:
+        - 4
+      zval_m:
+        - 3.0e-8


### PR DESCRIPTION
## Description

This PR contains the scripts and modifications for the kickoff iterations study. These include:

- A yml file with the parameters (kickoff_iterations_params.yml)
- A modified control strategy yml that is more aggressive (cstrat_nfov_band1.yaml)
- A script for generating comparison plots (CompareRunResults.py)
- Modifications to nulling_gitl.py to apply DM PMN creep and hysteresis and to calculate and apply Z6 to a DM
- Modifications to run_corgisim_nulling_gitl.py to incorporate the arguments for the kickoff iterations study

The kickoff iterations study currently includes DM PMN creep, DM hysteresis, 30 nm focus on the primary, 2.5 nm Z6 on DM1, 2.5 nm Z6 on DM2, LS misalignment, FSAM misalignment, and source/FPM shifts.

An example contrast vs. iteration plot is provided below.

## Checklist

Only check the ones that apply.

- [ ] Show contrast convergence plot of three iterations with compact model
- [ ] Show contrast convergence plot of three iterations with corgisim model
- [X] Added screenshots of expected results or test results on this PR
